### PR TITLE
Add caching for parsers & parse instruction events

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,7 +30,7 @@ export type InstructionParsers = Map<string, ParserFunction<Idl, string>>;
 /**
  * Map which keys are programIds (base58-encoded) and values are ix parsers
  */
-export type ProgramParsers = Map<string, { instructionCoder: BorshInstructionCoder; eventCoder: BorshEventCoder }>;
+export type IdlParser = Map<string, { instructionCoder: BorshInstructionCoder; eventCoder: BorshEventCoder }>;
 
 /**
  * Function that takes transaction ix and returns parsed variant

--- a/src/parsers.ts
+++ b/src/parsers.ts
@@ -123,6 +123,15 @@ export class SolanaParser {
 		this.idlParsers.delete(programId.toBase58());
 	}
 
+	/**
+	 * Adds (or updates) parser for provided programId
+	 * @param programId program id to add parser for
+	 * @param idl IDL that describes anchor program
+	 */
+	addParserFromIdl(programId: PublicKey | string, idl: Idl) {
+		this.instructionParsers.set(...this.buildIdlParser(new PublicKey(programId), idl));
+	}
+
 	private buildIdlParser(programId: PublicKey, idl: Idl): InstructionParserInfo {
 		const pubkey = programId.toBase58();
 		if (!this.idlParsers.has(pubkey)) {

--- a/tests/idl/jupiter_v6.ts
+++ b/tests/idl/jupiter_v6.ts
@@ -1,6 +1,6 @@
 export declare type Jupiter = {
 	accounts: [{ discriminator: [156, 247, 9, 188, 54, 108, 85, 77]; name: "TokenLedger" }];
-	address: "JUP2jxvXaqu7NQY1GmNF4m1vodw12LVXYxbFL2uJvfo";
+	address: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4";
 	constants: [];
 	errors: [
 		{ code: 6000; msg: "Empty route"; name: "EmptyRoute" },
@@ -410,7 +410,7 @@ export declare type Jupiter = {
 };
 export const IDL: Jupiter = {
 	accounts: [{ discriminator: [156, 247, 9, 188, 54, 108, 85, 77], name: "TokenLedger" }],
-	address: "JUP2jxvXaqu7NQY1GmNF4m1vodw12LVXYxbFL2uJvfo",
+	address: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4",
 	constants: [],
 	errors: [
 		{ code: 6000, msg: "Empty route", name: "EmptyRoute" },

--- a/tests/parseDlnDstTransaction.test.ts
+++ b/tests/parseDlnDstTransaction.test.ts
@@ -5,23 +5,30 @@ import assert from "assert";
 import { Connection, clusterApiUrl } from "@solana/web3.js";
 
 import { SolanaParser } from "../src";
-import { ParsedIdlInstruction } from "../src/interfaces";
+import { ParsedIdlEvent, ParsedIdlInstruction } from "../src/interfaces";
 
 import { IDL as DlnDstIdl, DlnDst } from "./idl/dst";
+import { IDL as JupIdl, Jupiter } from "./idl/jupiter_v6";
 
 const rpcConnection = new Connection(clusterApiUrl("mainnet-beta"));
-const parser = new SolanaParser([{ idl: DlnDstIdl, programId: "dst5MGcFPoBeREFAA5E3tU5ij8m5uVYwkzkSAbsLbNo" }]);
+const parser = new SolanaParser([
+	{ idl: DlnDstIdl, programId: "dst5MGcFPoBeREFAA5E3tU5ij8m5uVYwkzkSAbsLbNo" },
+	{ idl: JupIdl, programId: "JUP6LkbZbjS1jKKwapdHNy74zcZ3tLUZoi5QNyVTaV4" },
+]);
 
 describe("Test parse transaction", () => {
 	it("can parse fulfill tx", async () => {
 		const parsed = await parser.parseTransactionByHash(
 			rpcConnection,
-			"2H1jBCXaqoy8XZFvdsbZzC9bKU3V2C43YoDEJZVBMUg5wKf12LMt4fqT8j65D7SZY1PNfgMFiTRFXqpcAt5Wdc4z",
-			false,
+			"4V5XFQ8ViuWi4VxHWb7bCZtWGzyPgZnKTf6ABnC1VUXd2y5wgfrn8EGmzwst1iP19ySPA7jwx87KWX3S2GYUh8Lr",
+			true,
 		);
 
 		const fulfillOrder = parsed?.find((pix) => pix.name === "fulfill_order") as ParsedIdlInstruction<DlnDst, "fulfill_order">;
-		assert.equal(fulfillOrder.args.unvalidated_order.maker_order_nonce.toString(), "1730296839695");
+		assert.equal(fulfillOrder.args.unvalidated_order.maker_order_nonce.toString(), "1737321940254");
+
+		const swapEvent = parsed?.find((pix) => pix.name === "SwapEvent") as ParsedIdlEvent<Jupiter, "SwapEvent">;
+		assert.equal(swapEvent.args.output_amount.toString(), "1798522248");
 	});
 
 	it("can parse send_batch_unlock tx", async () => {


### PR DESCRIPTION
- Add caching for buildIdlParser. Otherwise, `BorshInstructionCoder` is created for every instruction parsed
- Add parser for instruction events
- Fix jup v6 program id